### PR TITLE
fixed init.vim error path config

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -33,7 +33,7 @@ if empty(glob('~/.config/nvim/_machine_specific.vim'))
 	let has_machine_specific_file = 0
 	silent! exec "!cp ~/.config/nvim/default_configs/_machine_specific_default.vim ~/.config/nvim/_machine_specific.vim"
 endif
-source $XDG_CONFIG_HOME/nvim/_machine_specific.vim
+source $HOME/.config/nvim/_machine_specific.vim
 
 
 " ====================
@@ -203,10 +203,10 @@ noremap <C-E> 5<C-e>
 
 
 
-source $XDG_CONFIG_HOME/nvim/cursor.vim
+source $HOME/.config/nvim/cursor.vim
 
 "If you use Qwerty keyboard, uncomment the next line.
-"source $XDG_CONFIG_HOME/nvim/cursor_for_qwerty.vim
+"source $HOME/nvim/cursor_for_qwerty.vim
 
 " ===
 " === Insert Mode Cursor Movement
@@ -291,7 +291,7 @@ noremap tmi :+tabmove<CR>
 " === Markdown Settings
 " ===
 " Snippets
-source $XDG_CONFIG_HOME/nvim/md-snippets.vim
+source $HOME/.config/nvim/md-snippets.vim
 " auto spell
 autocmd BufRead,BufNewFile *.md setlocal spell
 


### PR DESCRIPTION
- 当nvim放在～/.config 文件夹下时，会出现找不到相关文件的错误，后发现改为$HOME/.config/后即可正常使用，同时移除了对python2的配置。
- 系统环境: Manjaro 21.2.5
- 窗口管理器: dwm
- 终端环境: st