### PR TITLE
rewrite markdown snippets in Ultisnips syntax

### DIFF
--- a/Ultisnips/markdown.snippets
+++ b/Ultisnips/markdown.snippets
@@ -8,3 +8,70 @@ snippet tr "Table Row"
 | ${1:Term} | ${2:Definition} |
 ${0}
 endsnippet
+
+snippet ,n "Horizontal line" bA
+---
+
+$0
+endsnippet
+
+snippet ,b "Bold" wA
+**$0** <++>
+endsnippet
+
+snippet ,s "Strikethrough" wA
+~~$0~~ <++>
+endsnippet
+
+snippet ,i "Italic" wA
+*$0* <++>
+endsnippet
+
+snippet ,d "Code" wA
+`$0` <++>
+endsnippet
+
+snippet ,c "Code block" bA
+```$0
+<++>
+```
+
+<++>
+endsnippet
+
+snippet ,m "Task list" bA
+- [ ] $0
+endsnippet
+
+snippet ,p "Image" wA
+![$0](<++>) <++>
+endsnippet
+
+snippet ,a "Inline link" wA
+[$0](<++>) <++>
+endsnippet
+
+snippet ,1 "h1" bA
+# $0
+<++>
+endsnippet
+
+snippet ,2 "h2" bA
+## $0
+<++>
+endsnippet
+
+snippet ,3 "h3" bA
+### $0
+<++>
+endsnippet
+
+snippet ,4 "h4" bA
+#### $0
+<++>
+endsnippet
+
+snippet ,l "Long horizontal line" bA
+--------
+$0
+endsnippet

--- a/md-snippets.vim
+++ b/md-snippets.vim
@@ -2,17 +2,3 @@
 autocmd Filetype markdown inoremap <buffer> ,f <Esc>/<++><CR>:nohlsearch<CR>"_c4l
 autocmd Filetype markdown inoremap <buffer> <c-e> <Esc>/<++><CR>:nohlsearch<CR>"_c4l
 autocmd Filetype markdown inoremap <buffer> ,w <Esc>/ <++><CR>:nohlsearch<CR>"_c5l<CR>
-autocmd Filetype markdown inoremap <buffer> ,n ---<Enter><Enter>
-autocmd Filetype markdown inoremap <buffer> ,b **** <++><Esc>F*hi
-autocmd Filetype markdown inoremap <buffer> ,s ~~~~ <++><Esc>F~hi
-autocmd Filetype markdown inoremap <buffer> ,i ** <++><Esc>F*i
-autocmd Filetype markdown inoremap <buffer> ,d `` <++><Esc>F`i
-autocmd Filetype markdown inoremap <buffer> ,c ```<Enter><++><Enter>```<Enter><Enter><++><Esc>4kA
-autocmd Filetype markdown inoremap <buffer> ,m - [ ] 
-autocmd Filetype markdown inoremap <buffer> ,p ![](<++>) <++><Esc>F[a
-autocmd Filetype markdown inoremap <buffer> ,a [](<++>) <++><Esc>F[a
-autocmd Filetype markdown inoremap <buffer> ,1 #<Space><Enter><++><Esc>kA
-autocmd Filetype markdown inoremap <buffer> ,2 ##<Space><Enter><++><Esc>kA
-autocmd Filetype markdown inoremap <buffer> ,3 ###<Space><Enter><++><Esc>kA
-autocmd Filetype markdown inoremap <buffer> ,4 ####<Space><Enter><++><Esc>kA
-autocmd Filetype markdown inoremap <buffer> ,l --------<Enter>


### PR DESCRIPTION
Using Ultisnips syntax can be more intuitive than inoremapping.